### PR TITLE
html embed

### DIFF
--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,6 +1,5 @@
 {
 	"latest": "4.15.4",
-
-	"lastUpdateCheck": 1701152103526,
+	"lastUpdateCheck": 1701264866562,
 	"lastNotification": 1700971652793
 }

--- a/src/plugins/auto-content/server/services/mdx-service.js
+++ b/src/plugins/auto-content/server/services/mdx-service.js
@@ -45,16 +45,16 @@ const componentNameMap = Object.fromEntries(
 // utility function to construct JSX attributes from HTML DOM
 function stringifyAttributes(element, separator = ' ') {
   var attrStr = Array.from(element.attributes)
-      .filter(attr => attr.specified && attr.name !== 'class')
-      .map(attr => `${attr.name}="${attr.value}"`)
-      .join(separator)
+    .filter(attr => attr.specified && attr.name !== 'class')
+    .map(attr => `${attr.name}="${attr.value}"`)
+    .join(separator)
   if (attrStr.length > 0) {
     attrStr = separator + attrStr
   }
   return attrStr
 }
 
-// function for elements that consist of attributes and content only
+// Rule for elements that consist of attributes and content only
 turndownService.addRule('styles', {
   filter: function (node, options) {
     return (
@@ -68,6 +68,16 @@ turndownService.addRule('styles', {
     var attrStr = stringifyAttributes(node, ' ')
 
     return `<${tag}${attrStr}>${content}</${tag}>`
+  }
+})
+
+// Rule for allowing any HTML/JSX embed (possibly temporary)
+turndownService.addRule('htmlEmbed', {
+  filter: function (node, options) {
+    return node.nodeName === 'DIV' && node.getAttribute('class') === 'raw-html-embed'
+  },
+  replacement: function (content, node, options) {
+    return node.innerHTML
   }
 })
 

--- a/src/plugins/ckeditor/admin/src/components/CKEditorInput/Configurator.js
+++ b/src/plugins/ckeditor/admin/src/components/CKEditorInput/Configurator.js
@@ -87,7 +87,7 @@ const CKEDITOR_BASE_CONFIG_FOR_PRESETS = {
         '|',
         'bulletedList', 'numberedList',
         '-',
-        'sourceEditing',
+        'sourceEditing', 'htmlEmbed'
       ],
       shouldNotGroupWhenFull: true
     },
@@ -117,15 +117,15 @@ const CKEDITOR_BASE_CONFIG_FOR_PRESETS = {
         'toggleTableCaption'
       ]
     },
-    // htmlSupport: {
-    //   allow: [
-    //     // Enables all HTML elements and classes (for testing. not safe.)
-    //     {
-    //       name: /.*/,
-    //       attributes: true,
-    //       classes: true,
-    //       styles: true
-    //     },
+    htmlSupport: {
+      allow: [
+        // Enables all HTML elements and classes (for testing. not safe.)
+        {
+          name: /.*/,
+          attributes: true,
+          classes: true,
+          styles: true
+        },
     //     // Enables <div> elements with classes.
     //     {
     //       name: /^(div)$/,
@@ -145,8 +145,8 @@ const CKEDITOR_BASE_CONFIG_FOR_PRESETS = {
     //         style: true
     //       }
     //     }
-    //   ]
-    // }
+      ]
+    }
   }
 };
 


### PR DESCRIPTION
Adds HTML Embed functionality.
- Toolbar item in CKEditor
- MDX Parsing that grabs the `innerHTML` of any `raw-html-embed` elements.