### PR TITLE
plain-chunk slug auto generate fix, slug suffix cleanup, and json input validation

### DIFF
--- a/src/extensions/fieldSuffixes.js
+++ b/src/extensions/fieldSuffixes.js
@@ -1,0 +1,7 @@
+const fieldSuffixes = {
+    "chunk": {"fieldName": "Header", "suffix": "t"}, // text
+    "video": {"fieldName": "Title", "suffix": "t"}, // video
+    "plain-chunk": {"fieldName": "Header", "suffix": "pt"} // plain text
+};
+
+module.exports = fieldSuffixes;

--- a/src/extensions/validations.js
+++ b/src/extensions/validations.js
@@ -1,0 +1,25 @@
+'use strict';
+const { ApplicationError } = require('@strapi/utils/dist/errors');
+
+function validateKeyPhraseField(keyPhrases) {
+    let failed;
+    // Deal with empty fields
+    if (!keyPhrases) {
+        keyPhrases = "[]"
+    }
+    // Flag bad syntax
+    try {
+        const attemptedJSON = JSON.parse(keyPhrases);
+        failed = false;
+    } catch {
+        failed = true;
+    }
+    // This needs to be outside of a try/catch block
+    if (failed) {
+        throw new ApplicationError("Please check your JSON array's syntax", { policy: 'JSON-validate' });
+    }
+}
+
+module.exports = {
+    validateKeyPhraseField,
+};


### PR DESCRIPTION
Plain-chunks should generate slugs using headers automatically now (issue was with some necessary changes not being made in `updateFields.js` - have now changed the structure so that we'd only have to make changes on `fieldSuffixes.js` when adding new chunk component types). 

Also threw in input validation for the keyphrases field.