### PR TITLE
Keyphrase prompt change, error logging, keyphrase model change (to turbo-1106)

### DIFF
--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
-	"latest": "4.17.1",
-	"lastUpdateCheck": 1705551759557,
-	"lastNotification": 1705551859522
+	"latest": "4.20.0",
+	"lastUpdateCheck": 1707728384212,
+	"lastNotification": 1707728312471
 }

--- a/src/plugins/auto-content/admin/src/components/KeyPhraseGenerator/KeyPhraseGeneratorInput/index.js
+++ b/src/plugins/auto-content/admin/src/components/KeyPhraseGenerator/KeyPhraseGeneratorInput/index.js
@@ -117,15 +117,24 @@ export default function Index({
       if (!response.ok) {
         throw new Error(`Error! status: ${response.status}`);
       }
+
       const parsedResponse = await response.json().then((res) => {
-        return res.choices[0].message.content.trim();
+        // Probably will need to add a new column in Strapi db if we want to use the JSON feature
+        // const resArr = Object.values(JSON.parse(res.choices[0].message.content))[0];
+        // console.log(resArr);
+        // return resArr.join("\n");
+        if ("error" in res) {
+          return `Error generating kephrases!: ${res.error.message}`
+        } else {
+          return res.choices[0].message.content.trim();
+        }
       });
 
       onChange({
         target: { name, value: parsedResponse, type: attribute.type },
       });
     } catch (err) {
-      console.log(err);
+      throw new Error(`Error generating kephrases! status: ${err}`);
     }
   };
 
@@ -152,7 +161,7 @@ export default function Index({
 
       return generatedCleanText;
     } catch (err) {
-      console.log(err);
+      throw new Error(`Error generating clean text! status: ${err}`);
     }
   };
 
@@ -184,6 +193,7 @@ export default function Index({
       } catch (error) {
         console.error("Error fetching transcript:", error);
         fetchedTranscript = "Error fetching transcript";
+        throw new Error(`Error fetching transcript! status: ${error}`);
       }
 
       return fetchedTranscript;

--- a/src/plugins/auto-content/server/services/keyphrase-service.js
+++ b/src/plugins/auto-content/server/services/keyphrase-service.js
@@ -11,7 +11,7 @@ module.exports = ({ strapi }) => {
         {
           role: "user",
           content:
-            'Please generate a few important keyphrases from the following passage. The passage comes from an educational text, so it is important that the keyphrases are helpful for students. Provide a list of keyphrases in valid JSON format, like this: ["Keyphrase 1", "Keyphrase 2"] \n\n' + text + '\n\nKeyphrases: ',
+            'Generate 3 to 5 important keyphrases from the following passage. The passage comes from an educational text, so it is important that the keyphrases are helpful for students. A good keyphrase will be concise, and will likely be a noun phrase, like "patent infringement" or "epistemological belief". A bad keyphrase will be wordy and vague, like "extend the idea of scope", or will end mid-sentence like "defective condition unreasonably dangerous". Make sure the keyphrases do not overlap. For example, "sale" and "contract for sale" should not both be provided as keyphrases. Provide a list of keyphrases in valid JSON array format like this: ["Keyphrase 1", "Keyphrase 2"] . \n\nThe passage:' + text,
         },
       ];
       const response = await fetch(
@@ -25,7 +25,8 @@ module.exports = ({ strapi }) => {
               .config("API_TOKEN")}`,
           },
           body: JSON.stringify({
-            model: "gpt-3.5-turbo",
+            model:"gpt-3.5-turbo-1106",
+            // response_format:{ "type": "json_object" },
             messages: prompt,
             temperature: 0.7,
             max_tokens: 120,


### PR DESCRIPTION
A few smallish changes including
-prompt change 
-error logging
-keyphrase extraction model change (to turbo-1106; probably the cheapest model that supports `response_format={"type": "json_object"}` API calls)