### PR TITLE
Deletes unused chunks on page save

### DIFF
--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
 	"latest": "4.24.0",
-	"lastUpdateCheck": 1714156185229,
-	"lastNotification": 1713981906858
+	"lastUpdateCheck": 1714591159348,
+	"lastNotification": 1714591159340
 }

--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
-	"latest": "4.20.3",
-	"lastUpdateCheck": 1709426421219,
-	"lastNotification": 1709426421195
+	"latest": "4.24.0",
+	"lastUpdateCheck": 1714156185229,
+	"lastNotification": 1713981906858
 }

--- a/src/api/page/content-types/page/embeddings.js
+++ b/src/api/page/content-types/page/embeddings.js
@@ -31,9 +31,6 @@ async function generatePageEmbeddings(ctx) {
   );
 
   const deletePayload = {
-    text_slug: entry.text.slug,
-    module_slug: this_module_slug,
-    chapter_slug: chapter ? chapter.slug : null,
     page_slug: entry.slug,
     chunk_slugs: entry.Content.map((item) => item.Slug),
   }
@@ -46,22 +43,7 @@ const deleteAllEmbeddings = async (id) => {
     populate: "*",
   });
 
-  var chapter = null;
-  const chapter_id = entry.chapter ? entry.chapter.id : null;
-  var this_module_slug = null;
-  if (chapter_id) {
-    chapter = await strapi.entityService.findOne(
-      "api::chapter.chapter",
-      chapter_id,
-      { populate: "module" }
-    );
-    this_module_slug = chapter.module ? chapter.module.slug : null;
-  }
-
   const deletePayload = {
-    text_slug: entry.text.slug,
-    module_slug: this_module_slug,
-    chapter_slug: chapter ? chapter.slug : null,
     page_slug: entry.slug,
     chunk_slugs: [],
   }

--- a/src/api/page/content-types/page/embeddings.js
+++ b/src/api/page/content-types/page/embeddings.js
@@ -29,6 +29,16 @@ async function generatePageEmbeddings(ctx) {
   payload.map((item) =>
     strapi.service("api::page.page").generateEmbedding(item)
   );
+
+  const deletePayload = {
+    text_slug: entry.text.slug,
+    module_slug: this_module_slug,
+    chapter_slug: chapter ? chapter.slug : null,
+    page_slug: entry.slug,
+    chunk_slugs: entry.Content.map((item) => item.Slug),
+  }
+
+  strapi.service("api::page.page").deleteEmbeddings(deletePayload);
 }
 
 module.exports = {

--- a/src/api/page/content-types/page/embeddings.js
+++ b/src/api/page/content-types/page/embeddings.js
@@ -41,6 +41,35 @@ async function generatePageEmbeddings(ctx) {
   strapi.service("api::page.page").deleteEmbeddings(deletePayload);
 }
 
+const deleteAllEmbeddings = async (id) => {
+  const entry = await strapi.entityService.findOne("api::page.page", id, {
+    populate: "*",
+  });
+
+  var chapter = null;
+  const chapter_id = entry.chapter ? entry.chapter.id : null;
+  var this_module_slug = null;
+  if (chapter_id) {
+    chapter = await strapi.entityService.findOne(
+      "api::chapter.chapter",
+      chapter_id,
+      { populate: "module" }
+    );
+    this_module_slug = chapter.module ? chapter.module.slug : null;
+  }
+
+  const deletePayload = {
+    text_slug: entry.text.slug,
+    module_slug: this_module_slug,
+    chapter_slug: chapter ? chapter.slug : null,
+    page_slug: entry.slug,
+    chunk_slugs: [],
+  }
+
+  strapi.service("api::page.page").deleteEmbeddings(deletePayload);
+}
+
 module.exports = {
   generatePageEmbeddings,
+  deleteAllEmbeddings
 };

--- a/src/api/page/content-types/page/lifecycles.js
+++ b/src/api/page/content-types/page/lifecycles.js
@@ -1,4 +1,4 @@
-const { generatePageEmbeddings } = require('./embeddings');
+const { generatePageEmbeddings, deleteAllEmbeddings } = require('./embeddings');
 
 module.exports = { 
     afterCreate: async (event) => {
@@ -10,4 +10,9 @@ module.exports = {
         const { result, params } = event;
         generatePageEmbeddings(result);
     },
+
+    beforeDelete: async (event) => {
+        const { result, params } = event;
+        await deleteAllEmbeddings(params.where.id);
+    }
   };

--- a/src/api/page/services/page.js
+++ b/src/api/page/services/page.js
@@ -29,11 +29,10 @@ module.exports = createCoreService('api::page.page', ({ strapi }) =>  ({
         } catch (error) {
           console.log(error);
         }
-      }
+      },
 
       async deleteEmbeddings(ctx) {
         // for testing 
-        // const targetURL = `https://httpbin.org/delete`
         const targetURL = `https://itell-api.learlab.vanderbilt.edu/delete/unused`
 
         try {

--- a/src/api/page/services/page.js
+++ b/src/api/page/services/page.js
@@ -30,4 +30,27 @@ module.exports = createCoreService('api::page.page', ({ strapi }) =>  ({
           console.log(error);
         }
       }
+
+      async deleteEmbeddings(ctx) {
+        // for testing 
+        // const targetURL = `https://httpbin.org/delete`
+        const targetURL = `https://itell-api.learlab.vanderbilt.edu/delete/unused`
+
+        try {
+          const response = await fetch(
+            targetURL,
+            {
+              method: "DELETE",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify(ctx),
+            }
+          );
+          const result = await response;
+          return result;
+        } catch (error) {
+          console.log(error);
+        }
+      }
 }));

--- a/src/api/page/services/page.js
+++ b/src/api/page/services/page.js
@@ -33,7 +33,7 @@ module.exports = createCoreService('api::page.page', ({ strapi }) =>  ({
 
       async deleteEmbeddings(ctx) {
         // for testing 
-        const targetURL = `https://itell-api.learlab.vanderbilt.edu/delete/unused`
+        const targetURL = `https://itell-api.learlab.vanderbilt.edu/delete/embedding`
 
         try {
           const response = await fetch(

--- a/src/api/page/services/page.js
+++ b/src/api/page/services/page.js
@@ -39,7 +39,7 @@ module.exports = createCoreService('api::page.page', ({ strapi }) =>  ({
           const response = await fetch(
             targetURL,
             {
-              method: "DELETE",
+              method: "POST",
               headers: {
                 "Content-Type": "application/json",
               },

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2024-03-03T00:43:38.279Z"
+    "x-generation-date": "2024-04-26T19:00:03.421Z"
   },
   "x-strapi-config": {
     "path": "/documentation",

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2024-04-26T19:00:03.421Z"
+    "x-generation-date": "2024-05-02T02:58:44.643Z"
   },
   "x-strapi-config": {
     "path": "/documentation",


### PR DESCRIPTION
When a page is saved, a list of current chunk slugs for the page is sent to the backend. A list of current slugs in the vector store are retrieved and compared to the list in Strapi, and all that are not in Strapi are deleted. When a page is deleted, the same process occurs but the list is empty.