### PR TITLE
Add line breaks after section element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /src/plugins/*/node_modules/
 .tmp
 .DS_Store
+output

--- a/testing.js
+++ b/testing.js
@@ -93,19 +93,19 @@ async function entryPages(textData, startingPath) {
         let inputString = `<section className="content-chunk" aria-labelledby="${chunkSlug}" data-subsection-id="${chunkSlug}"`;
         stream.write(inputString);
         if(curChunk.ShowHeader) {
-          stream.write(` data-show-header="true">\n`);
+          stream.write(` data-show-header="true">\n\n`);
           if(curChunk.HeaderLevel === "H3"){
-            stream.write(`### ${curChunk.Header} \\{#${chunkSlug}}\n`);
+            stream.write(`### ${curChunk.Header} \\{#${chunkSlug}}\n\n`);
           }
           else if(curChunk.HeaderLevel === "H4"){
-            stream.write(`#### ${curChunk.Header} \\{#${chunkSlug}}\n`);
+            stream.write(`#### ${curChunk.Header} \\{#${chunkSlug}}\n\n`);
           }
           else{
-            stream.write(`## ${curChunk.Header} \\{#${chunkSlug}}\n`);
+            stream.write(`## ${curChunk.Header} \\{#${chunkSlug}}\n\n`);
           }
         }
         else{
-          stream.write(` data-show-header="false">\n`);
+          stream.write(` data-show-header="false">\n\n`);
           stream.write(`<h2 className="sr-only" id="${chunkSlug}">${curChunk.Header}</h2>\n\n`)
         }
         if (curChunk.MDX != null) {

--- a/testing.js
+++ b/testing.js
@@ -113,7 +113,7 @@ async function entryPages(textData, startingPath) {
             .replace(/(<br\s*\/?>\s*)+/g, '\n\n')
         )
         }
-        stream.write("\n</section>\n\n");
+        stream.write("\n\n</section>\n\n");
       } else if (curChunk["__component"] === "page.video") {
       }
     }


### PR DESCRIPTION
This PR adds an extra line break after the section element to make sure it is separated from potential follow-up headings. This is helpful for parsing the table of contents in next.js.