### PR TITLE
feat(parsing): Create MD Field

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+src/extensions/documentation/documentation/1.0.0 linguist-generated=true
+.strapi-updater.json linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-src/extensions/documentation/documentation/1.0.0 linguist-generated=true
+src/extensions/documentation/documentation/**/* linguist-generated=true
 .strapi-updater.json linguist-generated=true

--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
-	"latest": "4.25.10",
-	"lastUpdateCheck": 1725922863990,
+	"latest": "4.25.11",
+	"lastUpdateCheck": 1726073047497,
 	"lastNotification": 1725922863981
 }

--- a/src/components/page/chunk.json
+++ b/src/components/page/chunk.json
@@ -60,6 +60,9 @@
       ],
       "default": "H2",
       "required": true
+    },
+    "MD": {
+      "type": "text"
     }
   }
 }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2024-09-09T23:03:22.290Z"
+    "x-generation-date": "2024-09-11T19:26:13.200Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -724,6 +724,9 @@
                                       "H3",
                                       "H4"
                                     ]
+                                  },
+                                  "MD": {
+                                    "type": "string"
                                   }
                                 }
                               },
@@ -2282,6 +2285,9 @@
                                                     "H3",
                                                     "H4"
                                                   ]
+                                                },
+                                                "MD": {
+                                                  "type": "string"
                                                 }
                                               }
                                             },
@@ -3458,6 +3464,9 @@
                                                 "H3",
                                                 "H4"
                                               ]
+                                            },
+                                            "MD": {
+                                              "type": "string"
                                             }
                                           }
                                         },
@@ -4472,6 +4481,9 @@
               "H3",
               "H4"
             ]
+          },
+          "MD": {
+            "type": "string"
           }
         }
       },
@@ -4720,6 +4732,9 @@
                                     "H3",
                                     "H4"
                                   ]
+                                },
+                                "MD": {
+                                  "type": "string"
                                 }
                               }
                             },
@@ -5929,6 +5944,9 @@
                                                     "H3",
                                                     "H4"
                                                   ]
+                                                },
+                                                "MD": {
+                                                  "type": "string"
                                                 }
                                               }
                                             },

--- a/src/extensions/updateFields.js
+++ b/src/extensions/updateFields.js
@@ -58,8 +58,13 @@ async function generateChunkFields(event) {
     .service("plugin::auto-content.mdxService")
     .mdx(data.Text);
 
+  const md = await strapi
+    .service("plugin::auto-content.mdService")
+    .md(data.Text);
+  
   event.params.data.CleanText = cleanText;
   event.params.data.MDX = mdx;
+  event.params.data.MD = md;
 
   return event;
 }

--- a/src/plugins/auto-content/server/services/index.js
+++ b/src/plugins/auto-content/server/services/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   questionService: require("./question-service"),
   mdxService: require("./mdx-service"),
+  mdService: require("./md-service"),
   cleanTextService: require("./clean-text-service"),
   fetchTranscriptService: require("./fetch-transcript-service"),
   keyPhraseService: require("./keyphrase-service"),

--- a/src/plugins/auto-content/server/services/md-service.js
+++ b/src/plugins/auto-content/server/services/md-service.js
@@ -1,0 +1,329 @@
+"use strict";
+
+var TurndownService = require("joplin-turndown");
+var turndownPluginGfm = require("joplin-turndown-plugin-gfm");
+var gfm = turndownPluginGfm.gfm; // GitHub Flavored Markdown
+
+// Placeholder for page slugs; replaced by GithubPublish.js
+const pageSlug = "__temp_slug__";
+
+// Utility function to construct JSX attributes from HTML DOM
+function stringifyAttributes(element, separator = " ") {
+  var attrStr = Array.from(element.attributes)
+    .filter((attr) => attr.specified && attr.name !== "class")
+    .map((attr) => `${attr.name}="${attr.value}"`)
+    .join(separator);
+  if (attrStr.length > 0) {
+    attrStr = separator + attrStr;
+  }
+  return attrStr;
+}
+
+var turndownService = new TurndownService({
+  codeBlockStyle: "fenced",
+  blankReplacement: function (_content, node) {
+    if (
+      node.nodeName === "SECTION" &&
+      node.classList.contains("CodingSandbox")
+    ) {
+      // Preserve REPLs even when they are empty.
+      const language = node.querySelector("pre code").className.split(" ")[1];
+      const blockType = language === "python" ? "i-sandbox-py" : "i-sandbox-js";
+      return `<${blockType} page-slug="${pageSlug}" code="">\n</${blockType}>\n`;
+    } else if (node.isBlock) {
+      // Default behavior of blankReplacement is newlines for blank block elements.
+      return "\n\n";
+    } else {
+      // Empty string for blank inline elements.
+      return "";
+    }
+  },
+});
+
+turndownService.use(gfm);
+
+// Short name for turndownService.turndown
+const td = (html) => turndownService.turndown(html);
+
+// Rule for Fancy Fenced Code Blocks
+/* DataModel
+  <section class="StaticCode">
+      Attributes:
+      <p class="StaticAttributes">
+        attr_string
+      </p>
+      <div>
+          <pre><code class="language-python">code_content</code></pre>
+      </div>
+  </section>
+*/
+/* MDX Export
+  ```python attr_string
+  code_content
+  ```
+*/
+turndownService.addRule("StaticCode", {
+  filter: function (node) {
+    return (
+      node.nodeName === "SECTION" && node.getAttribute("class") === "StaticCode"
+    );
+  },
+  replacement: function (_content, node) {
+    const attributes = node.querySelector("p");
+    const attrStr = attributes ? attributes.textContent.trim() : "";
+
+    const codeBlock = node.querySelector("pre code");
+    const language = codeBlock.className.split("-")[1];
+
+    const codeContent = codeBlock.textContent.trim();
+
+    return `\`\`\`${language} ${attrStr}\n${codeContent}\n\`\`\``;
+  },
+});
+
+// Info
+/* DataModel
+  <section class="Info">
+    <h3 class="InfoTitle">info_title</h3>
+    <p class="InfoContent">info_content</p>
+  </section>
+*/
+/* MDX Export
+  <i-callout variant="info" title="info_title">
+  
+  info_content
+  
+  </i-callout>
+*/
+turndownService.addRule("Info", {
+  filter: function (node) {
+    return node.nodeName === "SECTION" && node.getAttribute("class") === "Info";
+  },
+  replacement: function (_content, node) {
+    const infoTitle = node.querySelector(".InfoTitle").textContent;
+    const infoContent = td(node.querySelector(".InfoContent").innerHTML);
+
+    return `<i-callout variant="info" title="${infoTitle}">\n\n${infoContent}\n\n</i-callout>\n`;
+  },
+});
+
+// Warnings
+/* DataModel
+  <section class="Warning">
+    warning_content_HTML
+  </section>
+*/
+/* MDX Export
+  <i-callout variant="warning">
+
+  warning_content_MD
+  
+  </i-callout>
+*/
+turndownService.addRule("Warning", {
+  filter: function (node) {
+    return (
+      node.nodeName === "SECTION" && node.getAttribute("class") === "Warning"
+    );
+  },
+  replacement: function (_content, node) {
+    const warningContent = td(node.innerHTML);
+    return `<i-callout variant="warning">\n\n${warningContent}\n\n</i-callout>\n`;
+  },
+});
+
+// Callouts
+/* DataModel
+  <section class="Callout">
+    callout_content_HTML
+  </section>
+*/
+/* MDX Export
+  <i-callout>
+  
+  callout_content_MD
+  
+  </i-callout>
+*/
+turndownService.addRule("Callout", {
+  filter: function (node) {
+    return (
+      node.nodeName === "SECTION" && node.getAttribute("class") === "Callout"
+    );
+  },
+  replacement: function (_content, node) {
+    const calloutContent = td(node.innerHTML);
+    return `<i-callout>\n\n${calloutContent}\n\n</i-callout>\n`;
+  },
+});
+
+// Accordions
+/* DataModel
+  <div class="accordion accordion-items-stay-open" data-accordion-id="">
+    <div class="accordion-item">
+        <div class="accordion-header">
+            <a class="accordion-button" href="#">
+                accordion_title
+            </a>
+        </div>
+        <div class="accordion-collapse collapse show">
+            <div class="accordion-body">
+                accordion_content_HTML
+            </div>
+        </div>
+    </div>
+  </div>
+*/
+/* MDX Export
+  <i-accordion value="first" class-name="prose dark:prose-invert">
+    <i-accordion-item value="1" title="accordion_title">
+    
+    accordion_content_MD
+
+    </i-accordion-item>
+  </i-accordion>
+*/
+turndownService.addRule("Accordion", {
+  filter: function (node) {
+    return node.nodeName === "DIV" && node.classList.contains("accordion");
+  },
+  replacement: function (_content, node) {
+    const itemsDataModel = Array.from(node.querySelectorAll(".accordion-item"));
+    let itemsJsxString = "";
+    let count = 0;
+    itemsDataModel.map((item) => {
+      // Get simple textContent from header.
+      const title = item.querySelector(".accordion-header").textContent.trim();
+
+      // Get innerHtml from body. This has not been thoroughly tested, but is intended
+      // to preserve e.g., lists, linebreaks that would be lost with .textContent.
+      const itemContent = td(item.querySelector(".accordion-body").innerHTML);
+
+      itemsJsxString += `<i-accordion-item value="${(count += 1)}" title="${title}">\n\n${itemContent}\n\n</i-accordion-item>\n`;
+    });
+    return `<i-accordion value="first" class-name="prose dark:prose-invert">\n${itemsJsxString}</i-accordion>\n`;
+  },
+});
+
+// Images
+/* DataModel
+  <figure class="image">
+    <img src="image.jpg" alt="image_description" />
+    <figcaption>image_caption</figcaption>
+  </figure>
+*/
+/* MDX Export
+  <i-image src="image.jpg" alt="image_description">
+  image_caption
+  </i-image>
+*/
+turndownService.addRule("Image", {
+  filter: function (node) {
+    return (
+      node.nodeName === "FIGURE" &&
+      node.getAttribute("class").startsWith("image")
+    );
+  },
+
+  replacement: function (_content, node) {
+    let firstImg = null;
+    let figcaption = null;
+
+    for (let i = 0; i < node.childNodes.length; i++) {
+      const child = node.childNodes[i];
+      if (child.nodeName === "IMG") firstImg = child;
+      if (child.nodeName === "FIGCAPTION") figcaption = child.textContent;
+    }
+
+    var attrStr = stringifyAttributes(firstImg, "\n  ");
+
+    if (figcaption) {
+      return `<i-image${attrStr}>\n\n${figcaption}\n\n</i-image>`;
+    } else {
+      return `<i-image${attrStr}>\n</i-image>`;
+    }
+  },
+});
+
+// Math
+/* DataModel
+  <span class="math-tex">\( mathStr \)</span>
+  <span class="math-tex">\[ mathStr \]</span>
+*/
+/* MDX Export
+   $ mathStr $
+  $$
+  mathStr
+  $$
+*/
+turndownService.addRule("Math", {
+  filter: function (node) {
+    return (
+      node.nodeName === "SPAN" &&
+      node.classList.contains("math-tex")
+    );
+  },
+  replacement: function (content, node, options) {
+    const mathStr = node.innerHTML
+    if (mathStr.startsWith("\\[")) {
+      // element is block, use `$$`
+      // Replace `\[` with `$$\n` and `\]` with `\n$$`
+      return mathStr.replace(/^\\\[/, "$$$$\n").replace(/\\\]$/, "\n$$$$")
+    } else if (mathStr.startsWith("\\(")) {
+      // element is in-line, use `$`
+      // Replace `\(` with ` $` (note the additional space) and `\)` with `$`
+      return mathStr.replace(/^\\\(/, " $").replace(/\\\)$/, "$")
+    } else {
+      console.log(`Math Parsing failed for "${mathStr}"`)
+    }
+  },
+});
+
+// Interactive Coding Sandboxes (REPLs)
+// Exports <Sandbox> for JavaScript and <Notebook> for Python
+/* DataModel
+  <section class="CodingSandbox">
+    <pre><code class="language-javascript">code_content</code></pre>
+  </section>
+*/
+/* MDX Export
+  <i-sandbox-js code = {`code_content`}>
+  </i-sandbox-js>
+*/
+turndownService.addRule("REPL", {
+  filter: function (node) {
+    return (
+      node.nodeName === "SECTION" &&
+      node.getAttribute("class") === "CodingSandbox"
+    );
+  },
+  replacement: function (_content, node) {
+    const codeBlock = node.querySelector("pre code");
+    const language = codeBlock.className.split("-")[1];
+
+    const codeContent = codeBlock.textContent.trim();
+
+    if (language === "python") {
+      return `<i-sandbox-py  page-slug="${pageSlug}" code={\`${codeContent}\`}>\n</i-sandbox-py>\n`;
+    } else if (language === "javascript") {
+      return `<i-sandbox-js page-slug="${pageSlug}" code={\`${codeContent}\`}>\n</i-sandbox-js>\n`;
+    }
+  },
+});
+
+// Converts linebreaks
+// Intended to help HTMLEmbeds create jsx compatible linebreaks.
+turndownService.addRule("LineBreaks", {
+  filter: "br",
+  replacement: function () {
+    return "\n\n";
+  },
+});
+
+module.exports = ({ strapi }) => {
+  const mdx = async (html) => {
+    if (!html) return null;
+    return td(html);
+  };
+  return { mdx };
+};

--- a/src/plugins/auto-content/server/services/md-service.js
+++ b/src/plugins/auto-content/server/services/md-service.js
@@ -321,9 +321,9 @@ turndownService.addRule("LineBreaks", {
 });
 
 module.exports = ({ strapi }) => {
-  const mdx = async (html) => {
+  const md = async (html) => {
     if (!html) return null;
     return td(html);
   };
-  return { mdx };
+  return { md };
 };


### PR DESCRIPTION
## Description

Adds a new `MD` field to chunks in Strapi. This is updated at the same time as the MDX field (which will eventually be deprecated).

Adds a new md-service for converting the CKEditor HTML into iTELL-Markdown.

This is a temporary solution, as I hope to rewrite this functionality in Rust and maintain it as a separate repository. This is partially motivated by performance concerns, and also a desire to relocate some of Strapi's dependencies into other repositories. The next step would be to move our CKEditor configuration into a separate repository. I believe this will make it easier to maintain and navigate these codebases.

## Additional Information

I had to guess at some details of the parsing logic. @qiushiyan will need to confirm/correct the following:

- `<Warning>` --> `<i-callout variant="warning">`
- `<Callout>` --> `<i-callout>` [no variant specified]
- `<Notebook>` --> ```<i-sandbox-py page_slug="foo" code={`foo = bar`}>```
- `<Sandbox>` --> ```<i-sandbox-js page_slug="foo" code={`const foo = bar`}>```

I am not currently ensuring that there are double linebreaks between list items. Is this strictly necessary? And is it required urgently? I can work this in fairly easily to the rust-based parser, but doing it in JS would require patching the `turndown` module that we are using.